### PR TITLE
Emit blur event on stopEdit in gridEdit

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -974,6 +974,7 @@
                 $scope.deepEdit = false;
 
                 $scope.stopEdit = function (evt) {
+                  evt.target.blur();
                   if ($scope.inputForm && !$scope.inputForm.$valid) {
                     evt.stopPropagation();
                     $scope.$emit(uiGridEditConstants.events.CANCEL_CELL_EDIT);


### PR DESCRIPTION
Using a custom template with `ng-model-options={ updateOn: 'blur' }` was not working for me. #4058 attempted to fix it, but the problem seemed to be that with the custom handling of key events, the blur event was never emitted for the edit cell. Manually emitting this fixes this, and I can't see why it would have adverse effects (other than potentially emitting 'blur' more than once).